### PR TITLE
fix: release workflow requires newer node version

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Setup Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
@@ -59,8 +59,8 @@ jobs:
       - name: Install Semantic Release
         run: |
           npm install -g semantic-release@24.2.0 @semantic-release/git@10.0.1 @semantic-release/github@11.0.0 @semantic-release/exec@6.0.3 semantic-release-helm3@2.9.3
-          npm install -g conventional-changelog-conventionalcommits@6.1.0 @commitlint/cli@17.6.6 @commitlint/config-conventional@17.6.6
-          npm install -g marked-mangle@1.0.1 marked-gfm-heading-id@3.0.4 semantic-release-conventional-commits@3.0.0
+          npm install -g conventional-changelog-conventionalcommits@8.0.0 @commitlint/cli@19.5.0 @commitlint/config-conventional@19.5.0
+          npm install -g marked-mangle@1.1.10 marked-gfm-heading-id@4.1.1 semantic-release-conventional-commits@3.0.0
 
       - name: Calculate Next Version
         env:


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the Node version used by the `Deploy Release Artifact` workflow.
- Updates the versions of `marked-mangle`, `marked-gfm-heading-id`, `conventional-changelog-conventionalcommits`,  `@commitlint/cli`,  and `@commitlint/config-conventional` dependencies.

### Related Issues

- Closes #40 
