### PR TITLE
chore(release): reset chart versions to v0.33.0

### DIFF
--- a/charts/solo-cluster-setup/Chart.yaml
+++ b/charts/solo-cluster-setup/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.0
+version: 0.33.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.34.0"
+appVersion: "0.33.0"
 
 dependencies:
   - name: operator

--- a/charts/solo-deployment/Chart.yaml
+++ b/charts/solo-deployment/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.0
+version: 0.33.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.34.0"
+appVersion: "0.33.0"
 
 # This is range of versions of Kubernetes server that is supported by this chart.
 # Note we need to use -0 suffix to support GKE version


### PR DESCRIPTION
## Description

This pull request changes the following:

- Resets chart versions to `0.33.0` in preparation to re-release `0.34.0`

### Related Issues

- Closes #46 
