### PR TITLE
fix: change data config config map for new hedera app version

### DIFF
--- a/.github/workflows/support/scripts/env.sh
+++ b/.github/workflows/support/scripts/env.sh
@@ -90,8 +90,8 @@ PLATFORM_VERSION=v0.54.0-alpha.4
 
 POD_MONITOR_ROLE="${POD_MONITOR_ROLE:-pod-monitor-role}"
 
-#NODE_NAMES=(node0 node1 node2 node3)
-NODE_NAMES=(node0 node1 node2)
+#NODE_NAMES=(node1 node2 node3 node4)
+NODE_NAMES=(node1 node2 node3)
 
 POD_MONITOR_ROLE="${POD_MONITOR_ROLE:-pod-monitor-role}"
 

--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -138,6 +138,27 @@ spec:
             items:
               - key: settings.txt
                 path: settings.txt
+        - name: network-node-hapi-app-api-permissions-properties
+          configMap:
+            name: network-node-data-config-cm
+            optional: true
+            items:
+              - key: api-permission.properties
+                path: api-permission.properties
+        - name: network-node-hapi-app-application-properties
+          configMap:
+            name: network-node-data-config-cm
+            optional: true
+            items:
+              - key: application.properties
+                path: application.properties
+        - name: network-node-hapi-app-bootstrap-properties
+          configMap:
+            name: network-node-data-config-cm
+            optional: true
+            items:
+              - key: bootstrap.properties
+                path: bootstrap.properties
         {{- if $networkNodeKeySecrets }}
         - name: network-node-keys
           secret:
@@ -192,9 +213,20 @@ spec:
             mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/settings.txt
             subPath: settings.txt
           {{- end }}
-          {{- if or $.Values.hedera.configMaps.apiPermissionsProperties $.Values.hedera.configMaps.applicationProperties $.Values.hedera.configMaps.bootstrapProperties }}
-          - name: network-node-data-config
-            mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/config
+          {{- if $.Values.hedera.configMaps.apiPermissionsProperties }}
+          - name: network-node-hapi-app-api-permissions-properties
+            mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/config/api-permission.properties
+            subPath: api-permission.properties
+          {{- end }}
+          {{- if $.Values.hedera.configMaps.applicationProperties }}
+          - name: network-node-hapi-app-application-properties
+            mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/config/application.properties
+            subPath: application.properties
+          {{- end }}
+          {{- if $.Values.hedera.configMaps.bootstrapProperties }}
+          - name: network-node-hapi-app-bootstrap-properties
+            mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/config/bootstrap.properties
+            subPath: bootstrap.properties
           {{- end }}
           {{- if $networkNodeKeySecrets }}
           - name: network-node-keys

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -314,9 +314,9 @@ hedera:
 
   # Only the name of the node is required. The rest of the configuration will be inherited from `defaults` section
   nodes:
-    - name: node0
-      accountId: 0.0.3
     - name: node1
-      accountId: 0.0.4
+      accountId: 0.0.3
     - name: node2
+      accountId: 0.0.4
+    - name: node3
       accountId: 0.0.5


### PR DESCRIPTION
## Description

This pull request changes the following:

- Change data/config mount path

### Related Issues

- Closes https://github.com/hashgraph/solo/issues/883


###  Test result

Test with loading hedeal local repo

no. longer has exception

```
[NodeStake[maxStake=1666666666666666666, minStake=0, nodeId=0, rewardRate=0, stake=0, stakeNotRewarded=0, stakeRewarded=0], NodeStake[maxStake=1666666666666666666, minStake=0, nodeId=1, rewardRate=0, stake=0, stakeNotRewarded=0, stakeRewarded=0], NodeStake[maxStake=1666666666666666666, minStake=0, nodeId=2, rewardRate=0, stake=0, stakeNotRewarded=0, stakeRewarded=0]]
2024-12-02 20:40:45.738 INFO  572  HandleWorkflow - Doing genesis setup @ 2024-12-02T20:40:45.506738Z
2024-12-02 20:40:45.759 INFO  551  V0490FileSchema - API Permissions loaded from data/config/api-permission.properties
2024-12-02 20:40:45.761 INFO  657  V0490FileSchema - Throttle definitions loaded from classpath resource genesis/throttles.json
```
