### PR TITLE
feat: add the ability to set a reserved static IP address for the consensus nodes HAProxy and Envoy Proxy

### DIFF
--- a/charts/solo-deployment/templates/services/envoy-svc.yaml
+++ b/charts/solo-deployment/templates/services/envoy-svc.yaml
@@ -15,12 +15,10 @@ metadata:
     solo.hedera.com/prometheus-endpoint: active
     {{- include "solo.testLabels" $ | nindent 4 }}
 spec:
-  {{- if $envoyProxy.loadBalancerEnabled }}
-  type: LoadBalancer
+  type: {{ $defaults.serviceType | default "ClusterIP" }}
   externalTrafficPolicy: Local
-  {{- if $node.envoyProxy.staticIP }}
-  loadBalancerIP: {{ $node.envoyProxy.staticIP }}
-  {{- end }}
+  {{- if $node.envoyProxyStaticIP }}
+  loadBalancerIP: {{ $node.envoyProxyStaticIP }}
   {{- end }}
   selector:
     app: envoy-proxy-{{ $node.name }}

--- a/charts/solo-deployment/templates/services/haproxy-svc.yaml
+++ b/charts/solo-deployment/templates/services/haproxy-svc.yaml
@@ -17,8 +17,8 @@ metadata:
 spec:
   type: {{ $defaults.serviceType | default "ClusterIP" }}
   externalTrafficPolicy: Local
-  {{- if $node.haproxy.staticIP }}
-  loadBalancerIP: {{ $node.haproxy.staticIP }}
+  {{- if $node.haproxyStaticIP }}
+  loadBalancerIP: {{ $node.haproxyStaticIP }}
   {{- end }}
   selector:
     app: haproxy-{{ $node.name }}

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -73,7 +73,7 @@ defaults:
       tag: "v1.21.1"
       pullPolicy: "IfNotPresent"
     resources: {}
-    loadBalancerEnabled: false
+    serviceType: "LoadBalancer"
   sidecars:
     recordStreamUploader:
       enabled: true
@@ -316,21 +316,15 @@ hedera:
   nodes:
     - name: node1
       accountId: 0.0.3
-      envoyProxy:
-        staticIP: "" # Static IP for Envoy, leave empty to not use
-      haproxy:
-        staticIP: "" # Static IP for HAProxy can be empty if not used
+      envoyProxyStaticIP: "" # Static IP for Envoy, leave empty to not use
+      haproxyStaticIP: "" # Static IP for HAProxy can be empty if not used
 
     - name: node2
       accountId: 0.0.4
-      envoyProxy:
-        staticIP: ""
-      haproxy:
-        staticIP: ""
+      envoyProxyStaticIP: ""
+      haproxyStaticIP: ""
 
     - name: node3
       accountId: 0.0.5
-      envoyProxy:
-        staticIP: ""
-      haproxy:
-        staticIP: ""
+      envoyProxyStaticIP: ""
+      haproxyStaticIP: ""


### PR DESCRIPTION
## Description

Adds a optional fields to nodes values that allows setting a static IP address for the haProxy and Envoy proxy

```yaml
envoyProxy:
  staticIP: ""
haproxy:
  staticIP: ""
``` 

### Related Issues

- Closes # [#53](https://github.com/hashgraph/solo-charts/issues/53)
