### PR TITLE
feat: moved 'acme-cluster-issuer' and 'haproxy-ingress' to dependencies of solo-cluster-chart

### DIFF
--- a/charts/solo-cluster-setup/Chart.yaml
+++ b/charts/solo-cluster-setup/Chart.yaml
@@ -46,3 +46,13 @@ dependencies:
     version: v1.13.3
     repository: https://charts.jetstack.io
     condition: cloud.certManager.enabled
+
+  - name: acme-cluster-issuer
+    version: 0.3.1
+    repository: https://swirldslabs.github.io/swirldslabs-helm-charts
+    condition: acmeClusterIssuer.enabled
+
+  - name: haproxy-ingress
+    version: 0.14.5
+    repository: https://haproxy-ingress.github.io/charts
+    condition: haproxyIngressController.enabled

--- a/charts/solo-cluster-setup/values.yaml
+++ b/charts/solo-cluster-setup/values.yaml
@@ -18,6 +18,12 @@ cloud:
   certManager:
     enabled: false
 
+acmeClusterIssuer:
+  enabled: false
+
+haproxyIngressController:
+  enabled: false
+
 cert-manager:
   namespace: cert-manager
   installCRDs: false
@@ -42,3 +48,21 @@ prometheus-stack:
         any: true  # fetch metrics from other namespaces
       serviceMonitorSelector: { }
       serviceMonitorSelectorNilUsesHelmValues: false
+
+# lets encrypt acme cluster issuer configuration
+acme-cluster-issuer:
+  issuers:
+    staging:
+      email: ""
+      name: '{{ .Values.global.namespaceOverride | default .Release.Namespace | printf "%s-letsencrypt-staging" }}'
+    production:
+      email: ""
+      name: '{{ .Values.global.namespaceOverride | default .Release.Namespace | printf "%s-letsencrypt-prod" }}'
+  solvers: # TODO change in: https://github.com/hashgraph/full-stack-testing/issues/631
+    http01:
+      solverType: "ingress"
+
+haproxy-ingress:
+  controller:
+    service:
+      loadBalancerIP: "" # the external IP address of the hedera mirror node explorer


### PR DESCRIPTION
… their values to the values file inside the 'solo-cluster-setup' chart

## Description
Moved `acme-cluster-issuer` and `haproxy-ingress` out of `mirror-node-explorer`, and into `solo-cluster-chart` 

- TBD

implement on solo's side

### Related Issues

- Closes [#58](https://github.com/hashgraph/solo-charts/issues/58)
