### PR TITLE
fix: genesis-network.json uses wrong value #64

### DIFF
--- a/charts/solo-deployment/templates/configmaps/network-node-data-config-cm.yaml
+++ b/charts/solo-deployment/templates/configmaps/network-node-data-config-cm.yaml
@@ -17,6 +17,6 @@ data:
   bootstrap.properties: {{ toYaml .Values.hedera.configMaps.bootstrapProperties  | indent 4 }}
 {{- end }}
 {{- if $.Values.hedera.configMaps.genesisNetworkJson }}
-  genesis-network.json: {{ toYaml .Values.hedera.configMaps.bootstrapProperties  | indent 4 }}
+  genesis-network.json: {{ toYaml .Values.hedera.configMaps.genesisNetworkJson  | indent 4 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Fixes usage of wrong value for `genesis-network.json`

### Related Issues

- Closes [#64](https://github.com/hashgraph/solo-charts/issues/64)
