### PR TITLE
feat: add support for genesis throttle configuration

### DIFF
--- a/charts/solo-deployment/templates/configmaps/network-node-data-config-cm.yaml
+++ b/charts/solo-deployment/templates/configmaps/network-node-data-config-cm.yaml
@@ -17,6 +17,9 @@ data:
   bootstrap.properties: {{ toYaml .Values.hedera.configMaps.bootstrapProperties  | indent 4 }}
 {{- end }}
 {{- if $.Values.hedera.configMaps.genesisNetworkJson }}
-  genesis-network.json: {{ toYaml .Values.hedera.configMaps.genesisNetworkJson  | indent 4 }}
+  genesis-network.json: {{ toYaml .Values.hedera.configMaps.genesisNetworkJson | indent 4 }}
+{{- end }}
+{{- if $.Values.hedera.configMaps.genesisThrottlesJson }}
+  genesis-throttles.json: {{ toYaml .Values.hedera.configMaps.genesisThrottlesJson | indent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -126,6 +126,13 @@ spec:
               - key: hedera-{{ $node.name }}.key
                 path: hedera.key
         {{- end }}
+        - name: network-node-genesis-throttles-json
+          configMap:
+            name: network-node-data-config-cm
+            optional: true
+            items:
+              - key: genesis-throttles.json
+                path: genesis-throttles.json
         - name: network-node-genesis-network-json
           configMap:
             name: network-node-data-config-cm
@@ -617,6 +624,23 @@ spec:
             - name: network-node-genesis-network-json
               mountPath: /opt/hgcapp/genesis-network/genesis-network.json
               subPath: genesis-network.json
+        {{- end }}
+
+        {{- if $.Values.hedera.configMaps.genesisThrottlesJson }}
+        - name: init-genesis-throttles
+          image: busybox:1.36.1
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              cp /opt/hgcapp/genesis-throttles/genesis-throttles.json /opt/hgcapp/services-hedera/HapiApp2.0/data/config
+              chmod 755 -R /opt/hgcapp/services-hedera/HapiApp2.0/data/config
+          volumeMounts:
+            - name: hgcapp-data-config
+              mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/config
+            - name: network-node-genesis-throttles-json
+              mountPath: /opt/hgcapp/genesis-throttles/genesis-throttles.json
+              subPath: genesis-throttles.json
         {{- end }}
 
         - name: init-record-streams-directories

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -321,6 +321,7 @@ hedera:
     log4j2Xml: ""
     settingsTxt: ""
     genesisNetworkJson: ""
+    genesisThrottlesJson: ""
 
   # Only the name of the node is required. The rest of the configuration will be inherited from `defaults` section
   nodes:


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds a new optional config map entry
- Adds a new optional init container
- Adds a new `hedera.configMaps.genesisThrottlesJson` values file entry
- Adds support for installing a `genesis-throttles.json` file in the `data/config` directory

### Related Issues

- Closes #76 
