### PR TITLE
fix: make the init-hedera container which verifies dns optional

### DIFF
--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -834,6 +834,8 @@ spec:
             - name: hgcapp-event-streams
               mountPath: /opt/hgcapp/eventStreams
               subPath: events_{{ $node.accountId }}
+
+        {{- if .Values.deployment.init.enableDnsValidation }}
         - name: init-hedera
           image: curlimages/curl:8.9.1
           command:
@@ -855,6 +857,7 @@ spec:
                 sleep 5;
               done
               return 0
+      {{- end }}
       {{- if gt $initContainersLength 0 }}
         {{- toYaml $.Values.hedera.initContainers | nindent 8 }}
       {{- end }}

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -268,6 +268,8 @@ minio-server:
 # hedera-mirror-node-explorer configuration
 # common deployment configuration
 deployment:
+  init:
+    enableDnsValidation: true
   podAnnotations: {}
   podLabels: {}
   nodeSelector: {}


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds a new `deployment.init.enableDnsValidation` values file entry
- Makes the `init-hedera` init container optional based on the new values file flag

### Related Issues

- Closes #96 
