### PR TITLE
fix: ensure block stream is passed the service endpoint as a cli arg

### DIFF
--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -380,23 +380,20 @@ spec:
         securityContext:
           {{- include "solo.hedera.security.context" . | nindent 10 }}
         command:
-          - /usr/bin/env
-          - python3.7
-          - /app/application.py
-          - --linux
-          - --watch-directory
-          - /opt/hgcapp/blockStreams/block-{{ $node.accountId }}
-          {{- if $.Values.cloud.minio.enabled }}
-          - --s3-endpoint
-          - http://{{ $minioserver.tenant.name }}-hl:9000
-          {{- else if $.Values.cloud.s3.enabled }}
-          - --s3-endpoint
-          - $S3_ENDPOINT
-          {{- end}}
-          {{- if $.Values.cloud.gcs.enabled }}
-          - --gcs-endpoint
-          - $GCS_ENDPOINT
-          {{- end }}
+          - /bin/sh
+          - -c
+          - |
+            /usr/bin/env python3.7 /app/application.py \
+              --linux \
+              --watch-directory /opt/hgcapp/blockStreams/block-{{ $node.accountId }} \
+              {{- if $.Values.cloud.minio.enabled }}
+              --s3-endpoint http://{{ $minioserver.tenant.name }}-hl:9000 \
+              {{- else if $.Values.cloud.s3.enabled }}
+              --s3-endpoint $S3_ENDPOINT \
+              {{- end}}
+              {{- if $.Values.cloud.gcs.enabled }}
+              --gcs-endpoint $GCS_ENDPOINT
+              {{- end }}
         volumeMounts:
           - name: hgcapp-blockstream
             mountPath: /opt/hgcapp/blockStreams


### PR DESCRIPTION
## Description

This pull request changes the following:

- Ensures the the block stream uploader receives the service endpoint as a CLI argument

### Related Issues

- Closes #100
