### PR TITLE
fix: add the consensus id back and also bump the container version to 0.33.2

### DIFF
--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -282,7 +282,13 @@ spec:
           - name: hgcapp-data-keys
             mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/keys
         env:
-          # these only get used as root, to set them for hedera user ID they need to be populated in the /etc/network-node/application.env
+          # these only get used as root, to set them for hedera user ID they need to be populated in the
+          # /etc/network-node/application.env, if you want the docker container to use them they need to also be in
+          # solo-containers > network-node.service > PassEnvironment
+          - name: CONSENSUS_NODE_ID
+            value: "{{ $node.nodeId }}"
+          - name: CONSENSUS_NODE_ALIAS
+            value: {{ $node.name }}
           {{- include "solo.defaultEnvVars" . | nindent 10 }}
           {{- with $rootExtraEnv }}
             {{- toYaml . | nindent 10 }}

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -58,7 +58,7 @@ defaults:
     image:
       registry: "ghcr.io"
       repository: "hashgraph/solo-containers/ubi8-init-java21"
-      tag: "0.33.1"
+      tag: "0.33.2"
       pullPolicy: "IfNotPresent"
     resources: {}
     extraEnv: []


### PR DESCRIPTION
## Description

This pull request changes the following:

- add the consensus id back
- bump the container version to 0.33.2

### Related Issues

- relates to https://github.com/hashgraph/solo/issues/1150
