### PR TITLE
feat: add support for service labels and annotations

### DIFF
--- a/charts/solo-deployment/templates/services/envoy-svc.yaml
+++ b/charts/solo-deployment/templates/services/envoy-svc.yaml
@@ -8,6 +8,10 @@ kind: Service
 metadata:
   name: envoy-proxy-{{ $node.name }}-svc
   namespace: {{ default $.Release.Namespace $.Values.global.namespaceOverride }}
+  {{- with $defaults.service.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     solo.hedera.com/type: envoy-proxy-svc
     solo.hedera.com/node-name: {{ $node.name }}
@@ -15,10 +19,13 @@ metadata:
     solo.hedera.com/account-id: {{ $node.accountId }}
     solo.hedera.com/prometheus-endpoint: active
     {{- include "solo.testLabels" $ | nindent 4 }}
+    {{- with $defaults.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  type: {{ $defaults.serviceType | default "ClusterIP" }}
-  {{- if or (eq $defaults.serviceType "LoadBalancer") (eq $defaults.serviceType "NodePort") }}
-  externalTrafficPolicy: {{ $defaults.externalTrafficPolicy | default "Local" }}
+  type: {{ $defaults.service.type | default "ClusterIP" }}
+  {{- if or (eq $defaults.service.type "LoadBalancer") (eq $defaults.service.type "NodePort") }}
+  externalTrafficPolicy: {{ $defaults.service.externalTrafficPolicy | default "Local" }}
   {{- end }}
   {{- if $node.envoyProxyStaticIP }}
   loadBalancerIP: {{ $node.envoyProxyStaticIP }}

--- a/charts/solo-deployment/templates/services/haproxy-svc.yaml
+++ b/charts/solo-deployment/templates/services/haproxy-svc.yaml
@@ -8,6 +8,10 @@ kind: Service
 metadata:
   name: haproxy-{{ $node.name }}-svc
   namespace: {{ default $.Release.Namespace $.Values.global.namespaceOverride }}
+  {{- with $defaults.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     solo.hedera.com/type: haproxy-svc
     solo.hedera.com/node-name: {{ $node.name }}
@@ -15,10 +19,13 @@ metadata:
     solo.hedera.com/account-id: {{ $node.accountId }}
     solo.hedera.com/prometheus-endpoint: active
     {{- include "solo.testLabels" $ | nindent 4 }}
+    {{- with $defaults.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  type: {{ $defaults.serviceType | default "ClusterIP" }}
-  {{- if or (eq $defaults.serviceType "LoadBalancer") (eq $defaults.serviceType "NodePort") }}
-  externalTrafficPolicy: {{ $defaults.externalTrafficPolicy | default "Local" }}
+  type: {{ default "ClusterIP" $defaults.service.type }}
+  {{- if or (eq $defaults.service.type "LoadBalancer") (eq $defaults.service.type "NodePort") }}
+  externalTrafficPolicy: {{ default "Local" $defaults.service.externalTrafficPolicy }}
   {{- end }}
   {{- if $node.haproxyStaticIP }}
   loadBalancerIP: {{ $node.haproxyStaticIP }}

--- a/charts/solo-deployment/templates/services/network-node-svc.yaml
+++ b/charts/solo-deployment/templates/services/network-node-svc.yaml
@@ -1,4 +1,4 @@
-{{- $defaults := $.Values.defaults.service }}
+{{- $defaults := $.Values.defaults.consensus }}
 {{ $headless := list true false }}
 {{ range $nodeConfig := ($.Values.hedera.nodes) }}
 {{ range $isHeadless := $headless}}
@@ -8,6 +8,10 @@ kind: Service
 metadata:
   name: network-{{ $nodeConfig.name }}{{ if not $isHeadless }}-svc{{ end }}
   namespace: {{ default $.Release.Namespace $.Values.global.namespaceOverride }}
+  {{- with $defaults.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     solo.hedera.com/type: network-node{{ if $isHeadless }}-headless{{ end }}-svc
     solo.hedera.com/node-name: {{ $nodeConfig.name }}
@@ -15,13 +19,16 @@ metadata:
     solo.hedera.com/node-id: "{{ $nodeConfig.nodeId }}"
     solo.hedera.com/prometheus-endpoint: active
     {{- include "solo.testLabels" $ | nindent 4 }}
+    {{- with $defaults.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if $isHeadless }}
   clusterIP: None
   {{- else }}
-  type: {{ $defaults.serviceType | default "ClusterIP" }}
-  {{- if or (eq $defaults.serviceType "LoadBalancer") (eq $defaults.serviceType "NodePort") }}
-  externalTrafficPolicy: {{ $defaults.externalTrafficPolicy | default "Local" }}
+  type: {{ $defaults.service.type | default "ClusterIP" }}
+  {{- if or (eq $defaults.service.type "LoadBalancer") (eq $defaults.service.type "NodePort") }}
+  externalTrafficPolicy: {{ $defaults.service.externalTrafficPolicy | default "Local" }}
   {{- end }}
   {{- end }}
   publishNotReadyAddresses: true

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -63,9 +63,12 @@ defaults:
       pullPolicy: "IfNotPresent"
     resources: {}
     extraEnv: []
-  service:
-    serviceType: "NodePort"
-    externalTrafficPolicy: "Local"
+  consensus:
+    service:
+      type: "NodePort"
+      externalTrafficPolicy: "Local"
+      annotations: { }
+      labels: { }
   haproxy:
     enabled: true
     nameOverride: "haproxy"
@@ -75,8 +78,11 @@ defaults:
       tag: "2.4.25"
       pullPolicy: "IfNotPresent"
     resources: {}
-    serviceType: "NodePort"
-    externalTrafficPolicy: "Local"
+    service:
+      type: "NodePort"
+      externalTrafficPolicy: "Local"
+      annotations: {}
+      labels: {}
   envoyProxy:
     enabled: true
     nameOverride: "envoy-proxy"
@@ -86,8 +92,11 @@ defaults:
       tag: "v1.21.1"
       pullPolicy: "IfNotPresent"
     resources: {}
-    serviceType: "NodePort"
-    externalTrafficPolicy: "Local"
+    service:
+      type: "NodePort"
+      externalTrafficPolicy: "Local"
+      annotations: {}
+      labels: {}
   sidecars:
     recordStreamUploader:
       enabled: true


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds support for haproxy, envoy, and consensus node `Service` labels and annotations.

### Related Issues

- Closes #114 
