### PR TITLE
feat: add data/libs and data/apps PVCs

### DIFF
--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -53,6 +53,8 @@ spec:
     {{ include "solo.volumeClaimTemplate" (dict "name" "hgcapp-output-pvc" "storage" $nodeStorage.output "storageClassName" $defaults.volumeClaims.storageClassName) | nindent 4 }}
     {{ include "solo.volumeClaimTemplate" (dict "name" "hgcapp-data-config-pvc" "storage" $nodeStorage.config "storageClassName" $defaults.volumeClaims.storageClassName) | nindent 4 }}
     {{ include "solo.volumeClaimTemplate" (dict "name" "hgcapp-data-keys-pvc" "storage" $nodeStorage.keys "storageClassName" $defaults.volumeClaims.storageClassName) | nindent 4 }}
+    {{ include "solo.volumeClaimTemplate" (dict "name" "hgcapp-data-libs-pvc" "storage" $nodeStorage.dataLibs "storageClassName" $defaults.volumeClaims.storageClassName) | nindent 4 }}
+    {{ include "solo.volumeClaimTemplate" (dict "name" "hgcapp-data-apps-pvc" "storage" $nodeStorage.dataApps "storageClassName" $defaults.volumeClaims.storageClassName) | nindent 4 }}
   {{- end }}
   template:
     metadata:
@@ -93,6 +95,8 @@ spec:
         {{ include "solo.volumeTemplate" (dict "name" "hgcapp-output" "claimName" (printf "%s-%s-%s" "hgcapp-output-pvc-network" $node.name "0") "pvcEnabled" $pvcEnabled ) | nindent 8 }}
         {{ include "solo.volumeTemplate" (dict "name" "hgcapp-data-config" "claimName" (printf "%s-%s-%s" "hgcapp-data-config-pvc-network" $node.name "0") "pvcEnabled" $pvcEnabled ) | nindent 8 }}
         {{ include "solo.volumeTemplate" (dict "name" "hgcapp-data-keys" "claimName" (printf "%s-%s-%s" "hgcapp-data-keys-pvc-network" $node.name "0") "pvcEnabled" $pvcEnabled ) | nindent 8 }}
+        {{ include "solo.volumeTemplate" (dict "name" "hgcapp-data-libs" "claimName" (printf "%s-%s-%s" "hgcapp-data-libs-pvc-network" $node.name "0") "pvcEnabled" $pvcEnabled ) | nindent 8 }}
+        {{ include "solo.volumeTemplate" (dict "name" "hgcapp-data-apps" "claimName" (printf "%s-%s-%s" "hgcapp-data-apps-pvc-network" $node.name "0") "pvcEnabled" $pvcEnabled ) | nindent 8 }}
         {{- if $otelCollector.enabled }}
         - name: otel-collector-volume
           configMap:
@@ -193,6 +197,10 @@ spec:
             mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/config
           - name: hgcapp-data-keys
             mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/keys
+          - name: hgcapp-data-libs
+            mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/lib
+          - name: hgcapp-data-apps
+            mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/apps
         env:
           # these only get used as root, to set them for hedera user ID they need to be populated in the
           # /etc/network-node/application.env, if you want the docker container to use them they need to also be in
@@ -790,6 +798,10 @@ spec:
             {{- end }}
             - name: shared-hapiapp
               mountPath: /shared-hapiapp
+            - name: hgcapp-data-libs
+              mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/lib
+            - name: hgcapp-data-apps
+              mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/data/apps
         {{- if $.Values.deployment.init.enableDnsValidation }}
         - name: init-hedera
           image: curlimages/curl:8.9.1

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -55,6 +55,8 @@ defaults:
       output: "5Gi"
       config: "1Gi"
       keys: "1Gi"
+      dataLibs: "1Gi"
+      dataApps: "1Gi"
   root: # root container
     image:
       registry: "ghcr.io"


### PR DESCRIPTION
## Description

This pull request introduces changes to the `charts/solo-deployment` Helm chart to add support for two new persistent volume claims (`hgcapp-data-libs` and `hgcapp-data-apps`) and their corresponding volume mounts. These changes ensure that additional data directories are properly configured and mounted in the network node StatefulSet.

### Persistent Volume Claim Enhancements:
* Added new volume claims `hgcapp-data-libs` and `hgcapp-data-apps` to the StatefulSet template, with storage sizes defined in `values.yaml` (`dataLibs` and `dataApps` set to `1Gi`). (`charts/solo-deployment/templates/network-node-statefulset.yaml`, `charts/solo-deployment/values.yaml`) [[1]](diffhunk://#diff-47beb3cf0961a07ed9ced5abe7a654fb88369bb565f3a8fa672ff12d0110da9fR56-R57) [[2]](diffhunk://#diff-f5e334e58d8f9b167cc0899244a7b1aa9af6af231e90c9163461a12e4658ffeaR58-R59)

### Volume Mount Updates:
* Updated the StatefulSet to include the new volumes `hgcapp-data-libs` and `hgcapp-data-apps` with mount paths `/opt/hgcapp/services-hedera/HapiApp2.0/data/lib` and `/opt/hgcapp/services-hedera/HapiApp2.0/data/apps`, respectively. (`charts/solo-deployment/templates/network-node-statefulset.yaml`) [[1]](diffhunk://#diff-47beb3cf0961a07ed9ced5abe7a654fb88369bb565f3a8fa672ff12d0110da9fR200-R203) [[2]](diffhunk://#diff-47beb3cf0961a07ed9ced5abe7a654fb88369bb565f3a8fa672ff12d0110da9fR801-R804)

### Related Issues

- Closes #118 
