### PR TITLE
feat: bump solo-containers to 0.36.1

### DIFF
--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -32,7 +32,7 @@ tester:
   image:
     registry: "ghcr.io"
     repository: "hashgraph/solo-containers/kubectl-bats"
-    tag: "0.36.0"
+    tag: "0.36.1"
     pullPolicy: "IfNotPresent"
   resources: {}
 
@@ -59,7 +59,7 @@ defaults:
     image:
       registry: "ghcr.io"
       repository: "hashgraph/solo-containers/ubi8-init-java21"
-      tag: "0.36.0"
+      tag: "0.36.1"
       pullPolicy: "IfNotPresent"
     resources: {}
     extraEnv: []


### PR DESCRIPTION
## Description

Bumps `solo-containers` to v0.36.1. This adds a change to `entrypoint.sh` which fixes an issue with M4 processors being unable to execute java21 scripts.
