### PR TITLE
fix: fix minio-secrets to correctly set id and password without double base 64 encoding when doing a helm upgrade

### DIFF
--- a/charts/solo-deployment/templates/secrets/uploader-mirror-secrets.yaml
+++ b/charts/solo-deployment/templates/secrets/uploader-mirror-secrets.yaml
@@ -1,7 +1,6 @@
 {{- $previous := lookup "v1" "Secret" .Release.Namespace "uploader-mirror-secrets" }}
 {{- $minio_accessKey := randAlpha 10  -}}
 {{- $minio_secretKey := randAlpha 10  -}}
-{{- $minio_config_env := printf "export MINIO_ROOT_USER=%s\nexport MINIO_ROOT_PASSWORD=%s" (coalesce ((($previous).data).S3_ACCESS_KEY) $minio_accessKey) (coalesce ((($previous).data).S3_SECRET_KEY) $minio_secretKey) -}}
 {{- $minio_url := printf "http://%s-hl:9000" (index $.Values "minio-server" "tenant" "name") -}}
 {{- if .Values.cloud.generateNewSecrets }}
 apiVersion: v1
@@ -11,7 +10,11 @@ metadata:
   namespace: {{ default $.Release.Namespace $.Values.global.namespaceOverride }}
 type: Opaque
 data:
-  config.env: {{ $minio_config_env | b64enc }}
+  {{- if and ((($previous).data).S3_ACCESS_KEY) ((($previous).data).S3_SECRET_KEY)}}
+  config.env: {{ printf "export MINIO_ROOT_USER=%s\nexport MINIO_ROOT_PASSWORD=%s" ((($previous).data).S3_ACCESS_KEY | b64dec)  ((($previous).data).S3_SECRET_KEY | b64dec) | b64enc -}}
+  {{- else }}
+  config.env: {{ printf "export MINIO_ROOT_USER=%s\nexport MINIO_ROOT_PASSWORD=%s" ($minio_accessKey) ($minio_secretKey) | b64enc }}
+  {{- end }}
 {{- end }}
 ---
 {{- if .Values.cloud.generateNewSecrets }}


### PR DESCRIPTION
## Description

This pull request changes the following:

- fix minio-secrets to correctly set id and password without double base 64 encoding when doing a helm upgrade

### Related Issues

- Closes #
