### PR TITLE
chore: make 'data/tmp' dir writable

### DIFF
--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -786,7 +786,7 @@ spec:
               ls -la /opt/hgcapp/services-hedera/HapiApp2.0/data/keys
               {{- end }}
 
-              chmod 755 -R /opt/hgcapp/services-hedera/HapiApp2.0/data/keys
+              chmod 755 -R /opt/hgcapp/services-hedera/HapiApp2.0/data
 
               {{- if $.Values.hedera.configMaps.applicationEnv }}
               # copy in the application.env to supply the environment variables to the application, will need


### PR DESCRIPTION
## Description

* give read/write permissions for `HapiApp2.0/data/` dir

## Manual Testing

```
npm run solo-test -- network deploy --deployment solo-e2e  --release-tag v0.62.0 --chart-dir /Users/user/projects/solo-charts/charts/
```

Cluster healthy, `node start` passes, mirror node, relay and explorer deployed successfully

### Related Issues

- Closes # https://github.com/hiero-ledger/solo/issues/1728


