### PR TITLE
chore: remove the scraping of network node 9999 metrics

### DIFF
--- a/charts/solo-deployment/config-files/otel-collector-config.yaml
+++ b/charts/solo-deployment/config-files/otel-collector-config.yaml
@@ -32,8 +32,21 @@ exporters:
     const_labels:
       source: p-{{ default "otel-collector" .otelDefaults.nameOverride }} # PromQL: {source="p-otel-collector"}
 
+  {{- if .otelDefaults.exporters.prometheusRemoteWrite.enabled }}
+  prometheusremotewrite:
+    endpoint: "{{ .otelDefaults.exporters.prometheusRemoteWrite.endpoint }}"
+    tls:
+      {{- .otelDefaults.exporters.prometheusRemoteWrite.tls | toYaml | nindent 6 }}
+    external_labels:
+      source: prw-{{ default "otel-collector" .otelDefaults.nameOverride }} # PromQL: {source="prw-otel-collector"}
+  {{- end }}
+
   otlp:
     endpoint: "{{ .otelDefaults.exporters.otlp.endpoint }}"
+    {{- if .otelDefaults.exporters.otlp.headers }}
+    headers:
+      {{- .otelDefaults.exporters.otlp.headers | toYaml | nindent 6 }}
+    {{- end }}
     tls:
       {{- .otelDefaults.exporters.otlp.tls | toYaml | nindent 6 }}
 
@@ -48,10 +61,12 @@ service:
       processors: [batch]
       exporters: [otlp]
     metrics:
-      receivers:
-        - prometheus
+      receivers: [otlp]
       processors:
         - attributes/addLabels
         - batch
       exporters:
         - prometheus
+        {{- if .otelDefaults.exporters.prometheusRemoteWrite.enabled }}
+        - prometheusremotewrite
+        {{- end }}

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -152,6 +152,10 @@ defaults:
         tag: "0.72.0"
         pullPolicy: "IfNotPresent"
       resources: { }
+      receivers:
+        prometheus:
+          scrapeTargets: [ 0.0.0.0:9999 ]  # hedera node metrics are exposed at port 9999
+          scrapeInterval: 5s
       exporters:
         otlp:
           endpoint: tempo:4317


### PR DESCRIPTION
## Description

* Removes the scraping of the network node's port `9999` metrics

### Related Issues

- Closes # https://github.com/hashgraph/solo-charts/issues/82
