### PR TITLE
chore: bump root-container version to v0.39.0

### DIFF
--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -79,7 +79,7 @@ defaults:
     image:
       registry: "ghcr.io"
       repository: "hashgraph/solo-containers/ubi8-init-java21"
-      tag: "0.38.0"
+      tag: "0.39.0"
       pullPolicy: "IfNotPresent"
     resources: { }
     extraEnv: [ ]


### PR DESCRIPTION
## Description

* from version  `v0.38.0` -> `v0.39.0`

### Related Issues

- Closes # https://github.com/hashgraph/solo-charts/issues/164
