### PR TITLE
fix: add support for topologySpreadConstraints

### DIFF
--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -77,6 +77,10 @@ spec:
       {{- default $node.tolerations $.Values.deployment.tolerations | toYaml | nindent 8 }}
       {{- end }}
       {{- if or $.Values.deployment.affinity $node.affinity }}
+      {{- if $.Values.deployment.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- $.Values.deployment.topologySpreadConstraints | toYaml | nindent 8 }}
+      {{- end }}
       affinity:
       {{- default $node.affinity $.Values.deployment.affinity | toYaml | nindent 8 }}
       {{- end }}

--- a/charts/solo-deployment/templates/proxy/envoy-deployment.yaml
+++ b/charts/solo-deployment/templates/proxy/envoy-deployment.yaml
@@ -31,6 +31,10 @@ spec:
       tolerations:
         {{- default $node.tolerations (default $.Values.deployment.tolerations $.Values.envoyDeployment.tolerations) | toYaml | nindent 8 }}
       {{- end }}
+      {{- if or $.Values.envoyDeployment.topologySpreadConstraints (or $.Values.deployment.topologySpreadConstraints $node.topologySpreadConstraints) }}
+      topologySpreadConstraints:
+        {{- default $node.topologySpreadConstraints (default $.Values.deployment.topologySpreadConstraints $.Values.envoyDeployment.topologySpreadConstraints) | toYaml | nindent 8 }}
+      {{- end }}
       {{- if or $.Values.envoyDeployment.affinity (or $.Values.deployment.affinity $node.affinity) }}
       affinity:
         {{- default $node.affinity (default $.Values.deployment.affinity $.Values.envoyDeployment.affinity) | toYaml | nindent 8 }}

--- a/charts/solo-deployment/templates/proxy/haproxy-deployment.yaml
+++ b/charts/solo-deployment/templates/proxy/haproxy-deployment.yaml
@@ -31,6 +31,10 @@ spec:
       tolerations:
         {{- default $node.tolerations (default $.Values.deployment.tolerations $.Values.haproxyDeployment.tolerations) | toYaml | nindent 8 }}
       {{- end }}
+      {{- if or $.Values.haproxyDeployment.topologySpreadConstraints (or $.Values.deployment.topologySpreadConstraints $node.topologySpreadConstraints) }}
+      topologySpreadConstraints:
+        {{- default $node.topologySpreadConstraints (default $.Values.deployment.topologySpreadConstraints $.Values.haproxyDeployment.topologySpreadConstraints) | toYaml | nindent 8 }}
+      {{- end }}
       {{- if or $.Values.haproxyDeployment.affinity (or $.Values.deployment.affinity $node.affinity) }}
       affinity:
         {{- default $node.affinity (default $.Values.deployment.affinity $.Values.haproxyDeployment.affinity) | toYaml | nindent 8 }}

--- a/charts/solo-deployment/templates/tests/test-deployment.yaml
+++ b/charts/solo-deployment/templates/tests/test-deployment.yaml
@@ -16,6 +16,10 @@ spec:
   tolerations:
     {{- $.Values.deployment.tolerations | toYaml | nindent 8 }}
     {{- end }}
+    {{- if $.Values.deployment.topologySpreadConstraints  }}
+  topologySpreadConstraints:
+    {{- $.Values.deployment.topologySpreadConstraints | toYaml | nindent 8 }}
+    {{- end }}
     {{- if $.Values.deployment.affinity }}
   affinity:
     {{- $.Values.deployment.affinity | toYaml | nindent 8 }}

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -224,6 +224,9 @@ deployment:
       operator: "Equal"
       value: "network"
       effect: "NoSchedule"
+  # Specify pod topology spread
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints    
+  topologySpreadConstraints: [ ]
   # Specify pod affinity
   # Use complete affinity spec starting with key "nodeAffinity:"
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
@@ -255,6 +258,9 @@ haproxyDeployment:
   podLabels: { }
   nodeSelector: { }
   tolerations: [ ]
+  # Specify pod topology spread
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints    
+  topologySpreadConstraints: [ ]
   # Specify pod affinity
   # Use complete affinity spec starting with key "nodeAffinity:"
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
@@ -267,6 +273,9 @@ envoyDeployment:
   podLabels: { }
   nodeSelector: { }
   tolerations: [ ]
+  # Specify pod topology spread
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints    
+  topologySpreadConstraints: [ ]
   # Specify pod affinity
   # Use complete affinity spec starting with key "nodeAffinity:"
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
@@ -298,6 +307,7 @@ hedera:
       haproxyStaticIP: "" # Static IP for HAProxy can be empty if not used
       nodeSelector: { }
       tolerations: [ ]
+      topologySpreadConstraints: [ ]
       # Specify pod affinity
       # Use complete affinity spec starting with key "nodeAffinity:"
       # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
@@ -311,6 +321,7 @@ hedera:
       haproxyStaticIP: ""
       nodeSelector: { }
       tolerations: [ ]
+      topologySpreadConstraints: [ ]
       affinity: { }
       priorityClassName: { }
     
@@ -321,5 +332,6 @@ hedera:
       haproxyStaticIP: ""
       nodeSelector: { }
       tolerations: [ ]
+      topologySpreadConstraints: [ ]
       affinity: { }
       priorityClassName: { }


### PR DESCRIPTION
Signed-off-by: Artur Reznikov <artur.reznikov@swirldslabs.com>

## Description

* adds support for `topologySpreadConstraints`

This pull request introduces support for Kubernetes topology spread constraints across various deployment templates and corresponding values files. This feature enhances pod distribution control for better cluster resource utilization and fault tolerance. The most important changes are grouped by theme below.

### Template Updates for Topology Spread Constraints:
* [`charts/solo-deployment/templates/network-node-statefulset.yaml`](diffhunk://#diff-47beb3cf0961a07ed9ced5abe7a654fb88369bb565f3a8fa672ff12d0110da9fR80-R83): Added support for topology spread constraints in the `network-node` StatefulSet template.
* [`charts/solo-deployment/templates/proxy/envoy-deployment.yaml`](diffhunk://#diff-6896ad97030ad0bf95e33e606913414d5735a3831a823b0197cb20d11162b957R34-R37): Incorporated topology spread constraints into the `envoy` proxy deployment template.
* [`charts/solo-deployment/templates/proxy/haproxy-deployment.yaml`](diffhunk://#diff-80aecd5e9ef4aa49bdccbb1739814eb5ae1c1345e4e9d78400b8b32aa481d194R34-R37): Enabled topology spread constraints in the `haproxy` proxy deployment template.
* [`charts/solo-deployment/templates/tests/test-deployment.yaml`](diffhunk://#diff-ceae1f6c84094ec24e8bf6ee3d76409ab8fc28dee7330a1a10daa964d956c545R19-R22): Added topology spread constraints to the test deployment template.

### Values File Updates for Topology Spread Constraints:
* [`charts/solo-deployment/values.yaml`](diffhunk://#diff-f5e334e58d8f9b167cc0899244a7b1aa9af6af231e90c9163461a12e4658ffeaR227-R229): Added topology spread constraints configuration across multiple sections (`deployment`, `haproxyDeployment`, `envoyDeployment`, and `hedera`), allowing users to specify constraints in the values file. [[1]](diffhunk://#diff-f5e334e58d8f9b167cc0899244a7b1aa9af6af231e90c9163461a12e4658ffeaR227-R229) [[2]](diffhunk://#diff-f5e334e58d8f9b167cc0899244a7b1aa9af6af231e90c9163461a12e4658ffeaR261-R263) [[3]](diffhunk://#diff-f5e334e58d8f9b167cc0899244a7b1aa9af6af231e90c9163461a12e4658ffeaR276-R278) [[4]](diffhunk://#diff-f5e334e58d8f9b167cc0899244a7b1aa9af6af231e90c9163461a12e4658ffeaR310) [[5]](diffhunk://#diff-f5e334e58d8f9b167cc0899244a7b1aa9af6af231e90c9163461a12e4658ffeaR324) [[6]](diffhunk://#diff-f5e334e58d8f9b167cc0899244a7b1aa9af6af231e90c9163461a12e4658ffeaR335)

### Related Issues

- Closes #
