### PR TITLE
feat: enable monitoring support installing crds from solo instead of solo deployment helm chart

### DIFF
--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -38,6 +38,7 @@ cheetah:
 crs:
   podLog:
     enabled: false
+
   serviceMonitor:
     enabled: false
 


### PR DESCRIPTION
## Description

### Related Issues

- Closes # https://github.com/hashgraph/solo-charts/issues/199
