### PR TITLE
fix: bump container image tags to 0.41.1 in ci-values.yaml and values.yaml

### DIFF
--- a/.github/workflows/support/ci/ci-values.yaml
+++ b/.github/workflows/support/ci/ci-values.yaml
@@ -3,6 +3,6 @@ tester:
   image:
     registry: "ghcr.io"
     repository: "hashgraph/solo-containers/kubectl-bats"
-    tag: "0.40.4"
+    tag: "0.41.1"
     pullPolicy: "IfNotPresent"
   resources: {}

--- a/.github/workflows/support/ci_test.sh
+++ b/.github/workflows/support/ci_test.sh
@@ -18,8 +18,8 @@ echo "--------------------------------------------------------------------------
 echo "Creating cluster and namespace"
 # kind delete cluster -n "${CLUSTER_NAME}" || true
 kind create cluster -n "${CLUSTER_NAME}" --config=dev-cluster.yaml
-# kind load docker-image ghcr.io/hashgraph/solo-containers/kubectl-bats:0.40.4 --name solo-charts-test
-# kind load docker-image ghcr.io/hashgraph/solo-containers/ubi8-init-java21:0.40.4 --name solo-charts-test
+# kind load docker-image ghcr.io/hashgraph/solo-containers/kubectl-bats:0.41.1 --name solo-charts-test
+# kind load docker-image ghcr.io/hashgraph/solo-containers/ubi8-init-java21:0.41.1 --name solo-charts-test
 
 kubectl create ns "${NAMESPACE}"
 kubectl get ns

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -52,7 +52,7 @@ tester:
   image:
     registry: "ghcr.io"
     repository: "hashgraph/solo-containers/kubectl-bats"
-    tag: "0.40.4"
+    tag: "0.41.1"
     pullPolicy: "IfNotPresent"
   resources: { }
 
@@ -80,7 +80,7 @@ defaults:
     image:
       registry: "ghcr.io"
       repository: "hashgraph/solo-containers/ubi8-init-java21"
-      tag: "0.40.4"
+      tag: "0.41.1"
       pullPolicy: "IfNotPresent"
     resources: { }
     extraEnv: [ ]
@@ -139,7 +139,7 @@ defaults:
       image:
         registry: "ghcr.io"
         repository: "hashgraph/solo-containers/backup-uploader"
-        tag: "0.40.4"
+        tag: "0.41.1"
         pullPolicy: "IfNotPresent"
       config:
         backupBucket: "backup"


### PR DESCRIPTION
## Description

This pull request changes the following:

- fix: bump container image tags to 0.41.1 in ci-values.yaml and values.yaml

### Related Issues

- Closes #
