### PR TITLE
feat: allow cheetah to pause and restart based on configmap change

### DIFF
--- a/charts/solo-deployment/config-files/cheetah/pipelines/block-streams.yaml
+++ b/charts/solo-deployment/config-files/cheetah/pipelines/block-streams.yaml
@@ -2,7 +2,7 @@
   enabled: true
   stopOnError: "{{ .cheetah.stopOnError }}" # stop the pipeline if any error occurs
   scanner:
-    directory: /opt/hgcapp/blockStreams/block-{{ .node.accountId }}
+    directory: /opt/hgcapp/blockStreams
     pattern: ".mf"
     interval: 100ms
     batchSize: 1000 # max number of files per scanned items batch

--- a/charts/solo-deployment/config-files/cheetah/pipelines/events-streams.yaml
+++ b/charts/solo-deployment/config-files/cheetah/pipelines/events-streams.yaml
@@ -2,7 +2,7 @@
   enabled: true
   stopOnError: "{{ .cheetah.stopOnError }}" # stop the pipeline if any error occurs
   scanner:
-    directory: /opt/hgcapp/eventsStreams/events_{{ .node.accountId }}
+    directory: /opt/hgcapp/eventsStreams
     pattern: ".evts_sig"
     interval: 100ms
     batchSize: 1000 # max number of files per scanned items batch

--- a/charts/solo-deployment/config-files/cheetah/pipelines/record-streams.yaml
+++ b/charts/solo-deployment/config-files/cheetah/pipelines/record-streams.yaml
@@ -2,7 +2,7 @@
   enabled: true
   stopOnError: "{{ .cheetah.stopOnError }}" # stop the pipeline if any error occurs
   scanner:
-    directory: /opt/hgcapp/recordStreams/record{{ .node.accountId }}
+    directory: /opt/hgcapp/recordStreams
     pattern: ".rcd_sig"
     interval: 100ms
     batchSize: 1000 # max number of files per scanned items batch

--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -19,9 +19,9 @@
 {{- $cheetah := $.Values.cheetah }}
 {{- $bucketPrefixString := toString $cloud.buckets.streamBucketPrefix }}
 {{- $bucketPrefix := empty $bucketPrefixString | ternary "" (printf "%s/" $bucketPrefixString) }}
-{{- $blockStreamBucketPrefix := printf "%sblockStreams/block-%s" $bucketPrefix $node.accountId }}
-{{- $recordStreamBucketPrefix := printf "%srecordstreams/record%s" $bucketPrefix $node.accountId }}
-{{ $eventStreamsBucketPrefix := printf "%seventsStreams/events_%s" $bucketPrefix $node.accountId -}}
+{{- $blockStreamBucketPrefix := printf "%sblockStreams" $bucketPrefix }}
+{{- $recordStreamBucketPrefix := printf "%srecordstreams" $bucketPrefix }}
+{{- $eventStreamsBucketPrefix := printf "%seventsStreams" $bucketPrefix }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -233,22 +233,17 @@ spec:
           - upload
           - --config
           - /app/config/cheetah.yaml
+          - --config-check-interval
+          - {{ default "30s" $cheetah.configCheckInterval }}
         volumeMounts:
           - name: hgcapp-blockstream
-            mountPath: /opt/hgcapp/blockStreams/block-{{ $node.accountId }}
-            subPath: block-{{ $node.accountId }}
+            mountPath: /opt/hgcapp/blockStreams
           - name: hgcapp-record-streams
-            mountPath: /opt/hgcapp/recordStreams/record{{ $node.accountId }}
-            subPath: record{{ $node.accountId }}
-          - name: hgcapp-record-streams-sidecar
-            mountPath: /opt/hgcapp/recordStreams/record{{ $node.accountId }}/sidecar
+            mountPath: /opt/hgcapp/recordStreams
           - name: hgcapp-event-streams
-            mountPath: /opt/hgcapp/eventsStreams/events_{{ $node.accountId }}
-            subPath: events_{{ $node.accountId }}
+            mountPath: /opt/hgcapp/eventsStreams
           - name: solo-cheetah-config
-            subPath: cheetah.yaml
-            mountPath: /app/config/cheetah.yaml
-            readOnly: true
+            mountPath: /app/config
         ports:
           - name: pprof
             containerPort: 6061
@@ -335,15 +330,14 @@ spec:
           - /app/bin/cheetah
           - upload
           - --config
-          - /app/config/cheetah.yaml
+          - /app/config/cheetah-block-streams.yaml
+          - --config-check-interval
+          - {{ default "30s" $cheetah.configCheckInterval }}
         volumeMounts:
           - name: hgcapp-blockstream
-            mountPath: /opt/hgcapp/blockStreams/block-{{ $node.accountId }}
-            subPath: block-{{ $node.accountId }}
+            mountPath: /opt/hgcapp/blockStreams
           - name: solo-cheetah-config
-            subPath: cheetah-block-streams.yaml
-            mountPath: /app/config/cheetah.yaml
-            readOnly: true
+            mountPath: /app/config
         ports:
           - name: pprof
             containerPort: 6061
@@ -419,15 +413,14 @@ spec:
           - /app/bin/cheetah
           - upload
           - --config
-          - /app/config/cheetah.yaml
+          - /app/config/cheetah-record-streams.yaml
+          - --config-check-interval
+          - {{ default "30s" $cheetah.configCheckInterval }}
         volumeMounts:
           - name: hgcapp-record-streams
-            mountPath: /opt/hgcapp/recordStreams/record{{ $node.accountId }}
-            subPath: record{{ $node.accountId }}
+            mountPath: /opt/hgcapp/recordStreams
           - name: solo-cheetah-config
-            subPath: cheetah-record-streams.yaml
-            mountPath: /app/config/cheetah.yaml
-            readOnly: true
+            mountPath: /app/config
         ports:
           - name: pprof
             containerPort: 6061
@@ -504,15 +497,14 @@ spec:
           - /app/bin/cheetah
           - upload
           - --config
-          - /app/config/cheetah.yaml
+          - /app/config/cheetah-events-streams.yaml
+          - --config-check-interval
+          - {{ default "30s" $cheetah.configCheckInterval }}
         volumeMounts:
           - name: hgcapp-event-streams
-            mountPath: /opt/hgcapp/eventsStreams/events_{{ $node.accountId }}
-            subPath: events_{{ $node.accountId }}
+            mountPath: /opt/hgcapp/eventsStreams
           - name: solo-cheetah-config
-            subPath: cheetah-events-streams.yaml
-            mountPath: /app/config/cheetah.yaml
-            readOnly: true
+            mountPath: /app/config
         ports:
           - name: pprof
             containerPort: 6061

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -22,12 +22,13 @@ cheetah:
   image:
     registry: "ghcr.io"
     repository: "hashgraph/solo-cheetah/cheetah"
-    tag: "0.4.0" # https://github.com/hashgraph/solo-cheetah/pkgs/container/solo-cheetah%2Fcheetah
+    tag: "0.4.1" # https://github.com/hashgraph/solo-cheetah/pkgs/container/solo-cheetah%2Fcheetah
     pullPolicy: "IfNotPresent"
   maxProcessors: 10 # max number of concurrent processors for each pipeline
   # whether it should stop the pipelines if any error occurs; if false, it will continue with the expectation that the
   # error may get fixed in the next run
   stopOnError: false
+  configCheckInterval: 30s # interval to check for config changes and update pipelines accordingly
   deployment:
     # if true, a single instance of cheetah will be deployed for all stream files (i.e. record-streams, events-streams, block-streams etc.)
     # WARNING: Other steams files uploader sidecar configuration will be ignored

--- a/dev/README.md
+++ b/dev/README.md
@@ -9,6 +9,22 @@ This document outlines the steps to set up a development environment for the pro
    - K9s (https://k9scli.io/)
    - `yq` from this link: [yq](https://github.com/mikefarah/yq/#install)
 
+## Steps to run using Solo
+- Install Node
+``` 
+nvm use 24
+```
+
+- Deploy the network and other components using Solo:
+```bash
+task deploy-network
+```
+
+- Destroy the network and other components using Solo:
+```bash
+task destroy-network
+```
+
 ## Steps to run the tests
 
 - Open a separate terminal and run the following command to deploy the network and other components:

--- a/dev/Taskfile.yml
+++ b/dev/Taskfile.yml
@@ -1,0 +1,198 @@
+version: '3'
+
+env:
+  CONSENSUS_NODE_VERSION: v0.66.0
+  SOLO_VERSION: v0.54.0
+  SOLO_CLUSTER_NAME: solo
+  SOLO_NAMESPACE: solo
+  SOLO_CLUSTER_SETUP_NAMESPACE: solo-cluster
+  SOLO_DEPLOYMENT: solo-deployment
+  NODEJS_VERSION: 20.18.0
+  NODES: 1
+  RELAY: false
+  MIRROR_NODE: false
+  HEDERA_EXPLORER: false
+  IMAGE: "solo-test:local"
+
+vars:
+  UUID:
+    sh: uuidgen | tr -d '-' | head -c 8 | tr '[:upper:]' '[:lower:]'
+    
+tasks:
+  install-solo:
+    desc: Install Solo CLI tool
+    silent: true
+    cmds:
+      - |
+        # Check if solo is installed and matches requested version
+        if command -v solo >/dev/null 2>&1; then
+          ver=$(solo --version 2>/dev/null || solo version 2>/dev/null || true)
+          if [ -n "$ver" ] && echo "$ver" | grep -q "{{.SOLO_VERSION}}"; then
+            echo "✅ Solo CLI {{.SOLO_VERSION}} already installed."
+            exit 0
+          else
+            echo "ℹ️  Found solo ($ver), but version differs. Installing {{.SOLO_VERSION}}..."
+          fi
+        else
+          echo "⬇️  Solo CLI not found. Installing {{.SOLO_VERSION}}..."
+        fi
+        npm install -g @hashgraph/solo@{{.SOLO_VERSION}}
+      - echo "✅ Solo CLI {{.SOLO_VERSION}} installed."
+  
+  deploy-network:
+    desc: Deploy a n-node Solo network
+    silent: true
+    deps:
+      - install-solo
+    cmds:
+      - echo "🚀 Deploying Solo network with NODES={{.NODES}} MIRROR_NODE={{.MIRROR_NODE}} HEDERA_EXPLORER={{.HEDERA_EXPLORER}} RELAY={{.RELAY}}..."
+      - task destroy-network
+      - |
+        if ! kind get clusters | grep -q "{{.SOLO_CLUSTER_NAME}}"; then
+          echo "⬇️  Creating Kind cluster {{.SOLO_CLUSTER_NAME}}..."
+          kind create cluster --name "{{.SOLO_CLUSTER_NAME}}"
+        else
+          echo "✅ Kind cluster {{.SOLO_CLUSTER_NAME}} already exists"
+        fi
+      - task enable-metrics-server
+      - task set-proxy
+      - echo "🧹 Removing old ~/.solo data..."
+      - rm -rf ~/.solo || true
+      - echo "⬇️  Initializing Solo..."
+      - solo init
+      - solo cluster-ref config connect --cluster-ref kind-{{.SOLO_CLUSTER_NAME}} --context kind-{{.SOLO_CLUSTER_NAME}}
+      - solo deployment config create -n "{{.SOLO_NAMESPACE}}" --deployment "{{.SOLO_DEPLOYMENT}}"
+      - solo deployment cluster attach --deployment "{{.SOLO_DEPLOYMENT}}" --cluster-ref kind-{{.SOLO_CLUSTER_NAME}} --num-consensus-nodes {{.NODES}}
+      - solo keys consensus generate --gossip-keys --tls-keys --deployment "{{.SOLO_DEPLOYMENT}}"
+      - solo cluster-ref config setup --prometheus-stack -s "{{.SOLO_CLUSTER_SETUP_NAMESPACE}}"
+      - solo consensus network deploy --deployment "{{.SOLO_DEPLOYMENT}}" --chart-dir ../charts
+      - solo consensus node setup --deployment "{{.SOLO_DEPLOYMENT}}" --release-tag "{{.CONSENSUS_NODE_VERSION}}"
+      - solo consensus node start --deployment "{{.SOLO_DEPLOYMENT}}"
+      - |
+        {{if .MIRROR_NODE}}
+        echo "📡 Deploying Mirror Node..."
+        solo mirror-node deploy --deployment "{{.SOLO_DEPLOYMENT}}" --cluster-ref kind-{{.SOLO_CLUSTER_NAME}}
+        {{end}}
+      - |
+        {{if .HEDERA_EXPLORER}}
+        echo "🌐 Deploying Explorer..."
+        solo explorer deploy --deployment "{{.SOLO_DEPLOYMENT}}" --cluster-ref kind-{{.SOLO_CLUSTER_NAME}}
+        {{end}}
+      - |
+        {{if .RELAY}}
+        echo "🔁 Deploying Relay..."
+        solo relay deploy -i node1 --deployment "{{.SOLO_DEPLOYMENT}}"
+        {{end}}
+      - echo "🎉 Solo network deployed with {{.NODES}} nodes! Run 👉 k9s to manage the cluster."
+  
+  destroy-network:
+    desc: Destroy the Solo network and clean up resources
+    silent: true
+    cmds:
+      - echo "💣 Destroying existing Solo network (if any)..."
+      - helm uninstall solo-cluster-setup -n "{{.SOLO_CLUSTER_SETUP_NAMESPACE}}" --wait --ignore-not-found || true
+      - kubectl delete ns "{{.SOLO_CLUSTER_SETUP_NAMESPACE}}" --wait --ignore-not-found || true
+      - kubectl delete ns "{{.SOLO_NAMESPACE}}" --wait --ignore-not-found || true
+      - rm -rf ~/.solo || true
+      - echo "✅ Solo network destroyed."
+  
+  enable-metrics-server:
+    desc: Enable metrics server in the Solo network (idempotent)
+    cmds:
+      - |
+        kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+        kubectl patch deployment -n kube-system metrics-server --type='json' \
+          -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kubelet-insecure-tls"}]'
+        echo "Metrics server is enabled."
+  
+  run-proxy:
+    desc: Run a proxy to the Solo network (daemon mode, idempotent)
+    cmds:
+      - |
+        if docker ps -q --filter "name=docker_registry_proxy" | grep -q .; then
+          echo "✅ Proxy is already running."
+          exit 0
+        fi
+        echo "Starting docker_registry_proxy..."
+        docker run --rm --name docker_registry_proxy -d \
+          --net kind --hostname docker-registry-proxy \
+          -p 0.0.0.0:3128:3128 \
+          -e ENABLE_MANIFEST_CACHE=true \
+          -e REGISTRIES="docker.io registry.k8s.io quay.io ghcr.io" \
+          -v "$HOME/docker_mirror_cache":/docker_mirror_cache \
+          -v "$HOME/docker_mirror_certs":/ca \
+          rpardini/docker-registry-proxy:0.6.5
+        sleep 5 # Wait for the proxy to start
+        echo "✅Proxy is running at localhost:3128"
+  
+  stop-proxy:
+    desc: Stop and remove the proxy container (idempotent)
+    cmds:
+      - echo "💣 Stopping and removing docker_registry_proxy container (if any)..."
+      - |
+        if docker ps -q --filter "name=docker_registry_proxy" | grep -q . || true; then
+          docker stop docker_registry_proxy || true
+          docker rm docker_registry_proxy || true
+          echo "✅Stopped and removed docker_registry_proxy container."
+        fi
+  
+  set-proxy:
+    desc: Set up Docker to use the proxy (idempotent)
+    cmds:
+      - task run-proxy
+      - echo "Setting up cluster to use the proxy..."
+      - |
+        # see: https://github.com/rpardini/docker-registry-proxy
+        KIND_NAME={{.SOLO_CLUSTER_NAME}}
+        SETUP_URL=http://docker-registry-proxy:3128/setup/systemd
+        docker exec solo-control-plane sh -c "\
+          curl "${SETUP_URL}" \
+          | sed s/docker\.service/containerd\.service/g \
+          | sed '/Environment/ s/$/ \"NO_PROXY=127.0.0.0\/8,10.0.0.0\/8,172.16.0.0\/12,192.168.0.0\/16\"/' \
+          | bash" # Configure every node in background
+        wait $! # Wait for all configurations to end
+        echo "✅ Cluster configured to use the proxy."
+  
+  check-docker:
+    desc: Check docker settings
+    silent: true
+    cmds:
+      - task run-proxy
+      - |
+        echo "🔍 Checking Docker Desktop resources..."
+        docker_info=$(docker info --format '{{"{{json .}}"}}')
+        mem=$(echo "$docker_info" | jq '.MemTotal' 2>/dev/null || echo 0)
+        cpus=$(echo "$docker_info" | jq '.NCPU' 2>/dev/null || echo 0)
+        min_mem_gb=31
+        min_cpus=8
+        min_mem=$(("${min_mem_gb}" * 1024 * 1024 * 1024))
+        if [ "$mem" -lt "$min_mem" ] || [ "$cpus" -lt "$min_cpus" ]; then
+          echo "❌ Docker Desktop resources too low: CPUs=$cpus, Mem=$(($mem/1024/1024/1024))GB"
+          echo "➡️  Please set at least ${min_mem_gb}GB RAM and ${min_cpus} CPUs in Docker Desktop > Settings > Resources."
+          exit 1
+        else
+          echo "✅ Docker Desktop resources OK: CPUs=$cpus, Mem=$(($mem/1024/1024/1024))GB"
+        fi
+  load-image:
+    desc: Load a local Docker image into the Kind cluster
+    vars:
+      IMAGE: "{{.IMAGE}}"
+    cmds:
+      - echo "🚚 Loading image {{.IMAGE}} into Kind cluster {{.SOLO_CLUSTER_NAME}}..."
+      - kind load docker-image "{{.IMAGE}}" -n "{{.SOLO_CLUSTER_NAME}}"
+      - echo "✅ Image {{.IMAGE}} loaded into Kind cluster {{.SOLO_CLUSTER_NAME}}."
+  refresh-node:
+    desc: Refresh a Solo node by running setup and start (idempotent)
+    vars:
+      NODE: "{{.NODE}}"
+    cmds:
+      - echo "🔄 Refreshing Solo node {{.NODE}}..."
+      - |
+        bash -c "
+        if [ -z '{{.NODE}}' ]; then
+          echo '❌ NODE variable is required. Usage: task refresh-node -- NODE=node1'
+          exit 1
+        fi
+        "
+        solo node setup --deployment "{{.SOLO_DEPLOYMENT}}" -i {{.NODE}}
+        solo node start --deployment "{{.SOLO_DEPLOYMENT}}" -i {{.NODE}}


### PR DESCRIPTION
## Changes
- allow cheetah to pause and restart based on config change (bump version to 0.4.1)
- allow cheetah to monitor the parent directory (/opt/hgcapp/eventsStreams) instead of a specific account directory (e.g events_0.0.3). 
   - This would allow account ID change feature in the future without needing any change in cheetah config
- We avoided subpath mounting for cheetah config so that as we update configmap, kubernetes would update the volume automatically. If we use subpath, then such automatic sync wouldn't occur.
   
   
## Demo
Watch: https://www.loom.com/share/1939b507423e457f8e3458bdbf261e98

## Descriptions
**Stream directory and configuration simplification:**
- Standardized stream directories by removing per-node subdirectories for block, record, and event streams in both configuration files and Kubernetes manifests, making file management simpler and more consistent. [[1]](diffhunk://#diff-c2f62a637e849419ba34640ddf7d9d001dc82ed8d6392d35f273d0c36b399fe6L5-R5) [[2]](diffhunk://#diff-43f8c6e319baa77c281ce9d033e8ce350aa66bfe267659ed34d21458c735e845L5-R5) [[3]](diffhunk://#diff-99989c9c98c4c95d0842688003a70d1eb9f3cdd6b738bed17075bea9aeec023eL5-R5) [[4]](diffhunk://#diff-47beb3cf0961a07ed9ced5abe7a654fb88369bb565f3a8fa672ff12d0110da9fL22-R24) [[5]](diffhunk://#diff-47beb3cf0961a07ed9ced5abe7a654fb88369bb565f3a8fa672ff12d0110da9fR236-R246) [[6]](diffhunk://#diff-47beb3cf0961a07ed9ced5abe7a654fb88369bb565f3a8fa672ff12d0110da9fL338-R340) [[7]](diffhunk://#diff-47beb3cf0961a07ed9ced5abe7a654fb88369bb565f3a8fa672ff12d0110da9fL422-R423) [[8]](diffhunk://#diff-47beb3cf0961a07ed9ced5abe7a654fb88369bb565f3a8fa672ff12d0110da9fL507-R507)

**Cheetah component updates:**
- Upgraded the Cheetah image to version `0.4.1` and introduced a configurable `configCheckInterval` to allow for dynamic configuration reloads.

**Developer tooling and automation:**
- Added a comprehensive `Taskfile.yml` with tasks to automate Solo CLI installation, network deployment, teardown, proxy setup, metrics server enablement, Docker checks, and image loading, greatly improving the developer experience for local testing and iteration.
- Updated the development documentation (`README.md`) to include clear instructions for using Solo and the new task-based workflow.



### Related Issues

- Closes #221 
- Original request: https://github.com/hashgraph/solo-cheetah/issues/100