### PR TITLE
fix: switch from postgresql-ha to postgresql chart

### DIFF
--- a/charts/solo-shared-resources/Chart.lock
+++ b/charts/solo-shared-resources/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: postgresql-ha
+- name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.3.17
+  version: 18.5.9
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 22.0.7
-digest: sha256:2dc483daf030efc4a4fa75f428d4dab900633a0a5cdf05e9cc709614e4c5cf42
-generated: "2026-01-22T14:06:04.309373+02:00"
+digest: sha256:1ab9dedccbd3e2f27ea715d9bca582ba786f98ee0da5350fe69a5bf98d006fa7
+generated: "2026-03-20T12:16:19.788018+02:00"

--- a/charts/solo-shared-resources/Chart.yaml
+++ b/charts/solo-shared-resources/Chart.yaml
@@ -31,9 +31,9 @@ kubeVersion: ">=1.25.0-0"
 dependencies:
   - alias: postgresql
     condition: postgresql.enabled
-    name: postgresql-ha
+    name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 15.3.17
+    version: 18.5.9
   - condition: redis.enabled
     name: redis
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/solo-shared-resources/templates/_helpers.tpl
+++ b/charts/solo-shared-resources/templates/_helpers.tpl
@@ -26,10 +26,8 @@ Constructs the database host that should be used by all components.
 {{- define "solo-shared-resources.db" -}}
 {{- if .Values.db.host -}}
 {{- tpl .Values.db.host . -}}
-{{- else if and .Values.postgresql.enabled (gt (.Values.postgresql.pgpool.replicaCount | int) 0) -}}
-{{- include "postgresql-ha.pgpool" .Subcharts.postgresql -}}
 {{- else if .Values.postgresql.enabled -}}
-{{- include "postgresql-ha.postgresql" .Subcharts.postgresql -}}
+{{- include "common.names.fullname" .Subcharts.postgresql -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/solo-shared-resources/templates/secret-passwords.yaml
+++ b/charts/solo-shared-resources/templates/secret-passwords.yaml
@@ -12,8 +12,6 @@ metadata:
   namespace: {{ include "solo-shared-resources.namespace" . }}
 stringData:
   {{ if .Values.postgresql.enabled -}}
-  admin-password: {{ coalesce .Values.postgresql.pgpool.adminPassword (get $passwords "admin-password" | default "" | b64dec) (randAlphaNum 40) | quote }}
-  password: {{ coalesce .Values.postgresql.postgresql.password (get $passwords "password" | default "" | b64dec) (randAlphaNum 40) | quote }}
-  repmgr-password: {{ coalesce .Values.postgresql.postgresql.repmgrPassword (get $passwords "repmgr-password" | default "" | b64dec) (randAlphaNum 40) | quote }}
+  password: {{ (get $passwords "password" | default "" | b64dec) | default (randAlphaNum 40) | quote }}
   POSTGRESQL_TIMEZONE: "UTC"
   {{ end -}}

--- a/charts/solo-shared-resources/values.yaml
+++ b/charts/solo-shared-resources/values.yaml
@@ -9,54 +9,14 @@ labels: {}
 
 postgresql:
   enabled: true
-  metrics:
-    enabled: false
-    image:
-      repository: bitnamilegacy/postgres-exporter
-    resources:
-      limits:
-        cpu: 50m
-        memory: 50Mi
-      requests:
-        cpu: 20m
-        memory: 25Mi
   nameOverride: postgres
   persistence:
     size: 500Gi
-  pgpool:
-    adminPassword: ""  # Randomly generated if left blank
-    childLifeTime: 60
-    childMaxConnections: 2
+  auth:
     existingSecret: solo-shared-resources-passwords
-    image:
-      debug: true
-      repository: bitnamilegacy/pgpool
-    numInitChildren: 100
-    podAntiAffinityPreset: soft
-    podLabels:
-      role: db
-    pdb:
-      create: true
-    reservedConnections: 0
-    resources:
-      limits:
-        cpu: 600m
-        memory: 750Mi
-      requests:
-        cpu: 200m
-        memory: 256Mi
-  postgresql:
-    existingSecret: solo-shared-resources-passwords
-    extraEnvVarsSecret: solo-shared-resources-passwords
-    image:
-      debug: true
-      repository: bitnamilegacy/postgresql-repmgr
-      tag: 17.6.0-debian-12-r2
-    maxConnections: 200
-    password: ""  # Randomly generated if left blank
-    podAntiAffinityPreset: soft
-    replicaCount: 1
-    repmgrPassword: ""  # Randomly generated if left blank
+    secretKeys:
+      adminPasswordKey: password
+  primary:
     resources:
       limits:
         cpu: 1500m
@@ -64,7 +24,6 @@ postgresql:
       requests:
         cpu: 250m
         memory: 500Mi
-    repmgrLogLevel: DEBUG
 
 redis:
   auth:


### PR DESCRIPTION
## Description

This PR switches the shared-resources chart from using `postgresql-ha` to `postgresql`. This reduces the memory footprint of the Postgres service and removes the `pgpool` pod, since solo only requires a single Postgres instance.

### Related Issues

- Is part of this [solo issue](https://github.com/hiero-ledger/solo/issues/3527)
