### PR TITLE
fix: reduce network probe delays

### DIFF
--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -646,10 +646,16 @@ spec:
           httpGet:
             path: /
             port: health
+          initialDelaySeconds: {{ default 0 $otelCollector.probes.initialDelaySeconds }}
+          periodSeconds: {{ default 1 $otelCollector.probes.periodSeconds }}
+          failureThreshold: {{ default 60 $otelCollector.probes.failureThreshold }}
         readinessProbe:
           httpGet:
             path: /
             port: health
+          initialDelaySeconds: {{ default 0 $otelCollector.probes.initialDelaySeconds }}
+          periodSeconds: {{ default 1 $otelCollector.probes.periodSeconds }}
+          failureThreshold: {{ default 60 $otelCollector.probes.failureThreshold }}
         volumeMounts:
           - name: otel-collector-volume
             mountPath: /etc/otelcol-contrib/config.yaml

--- a/charts/solo-deployment/templates/proxy/haproxy-deployment.yaml
+++ b/charts/solo-deployment/templates/proxy/haproxy-deployment.yaml
@@ -87,22 +87,22 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 50211
-          initialDelaySeconds: 15
-          periodSeconds: 10
+          initialDelaySeconds: {{ default 0 $haproxy.probes.livenessInitialDelaySeconds }}
+          periodSeconds: {{ default 1 $haproxy.probes.livenessPeriodSeconds }}
           timeoutSeconds: {{ default 5 $haproxy.probes.timeoutSeconds }}
           failureThreshold: 6
         readinessProbe:
           tcpSocket:
             port: 50211
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          initialDelaySeconds: {{ default 0 $haproxy.probes.readinessInitialDelaySeconds }}
+          periodSeconds: {{ default 1 $haproxy.probes.readinessPeriodSeconds }}
           timeoutSeconds: {{ default 5 $haproxy.probes.timeoutSeconds }}
           failureThreshold: 6
         startupProbe:
           tcpSocket:
             port: 50211
-          initialDelaySeconds: 10
-          periodSeconds: 5
+          initialDelaySeconds: {{ default 0 $haproxy.probes.startupInitialDelaySeconds }}
+          periodSeconds: {{ default 1 $haproxy.probes.startupPeriodSeconds }}
           timeoutSeconds: {{ default 5 $haproxy.probes.timeoutSeconds }}
           failureThreshold: 60
         volumeMounts:

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -109,6 +109,12 @@ defaults:
     tcpKeepAlive: true
     probes:
       timeoutSeconds: 5
+      livenessInitialDelaySeconds: 0
+      livenessPeriodSeconds: 1
+      readinessInitialDelaySeconds: 0
+      readinessPeriodSeconds: 1
+      startupInitialDelaySeconds: 0
+      startupPeriodSeconds: 1
     resources: { }
     service:
       type: "NodePort"
@@ -164,6 +170,10 @@ defaults:
         tag: "0.72.0"
         pullPolicy: "IfNotPresent"
       resources: { }
+      probes:
+        initialDelaySeconds: 0
+        periodSeconds: 1
+        failureThreshold: 60
       receivers:
         prometheus:
           scrapeTargets: [ localhost:9999 ]  # hedera node metrics are exposed at port 9999
@@ -222,6 +232,18 @@ minio-server:
       name: minio-secrets
     certificate:
       requestAutoCert: false
+    readinessProbe:
+      initialDelaySeconds: 0
+      periodSeconds: 1
+      failureThreshold: 60
+    livenessProbe:
+      initialDelaySeconds: 0
+      periodSeconds: 1
+      failureThreshold: 60
+    startupProbe:
+      initialDelaySeconds: 0
+      periodSeconds: 1
+      failureThreshold: 60
   environment:
     MINIO_BROWSER_LOGIN_ANIMATION: off # https://github.com/minio/console/issues/2539#issuecomment-1619211962
 


### PR DESCRIPTION
## Description

This PR reduces the time it takes for `haproxy`, `envoy-proxy`, and `minio-server` to be marked as ready by up to 15 seconds by reducing the initial delay for the liveness probes and reducing the ping intervals

### Related Issues

- Closes #
