### PR TITLE
feat: switch to debian-s6-java25 and remove privileged access

### DIFF
--- a/charts/solo-deployment/templates/_helpers.tpl
+++ b/charts/solo-deployment/templates/_helpers.tpl
@@ -21,12 +21,6 @@ runAsUser: 0
 runAsGroup: 0
 {{- end }}
 
-{{- define "solo.root.security.context.privileged" -}}
-runAsUser: 0
-runAsGroup: 0
-privileged: true
-{{- end }}
-
 {{- define "solo.defaultEnvVars" -}}
 - name: POD_IP
   valueFrom:

--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -163,8 +163,6 @@ spec:
       - name: {{ $root.nameOverride | default "root-container" }}
         image: {{ include "solo.container.image" (dict "image" $rootImage "Chart" $.Chart "defaults" $.Values.defaults) }}
         imagePullPolicy: {{ include "solo.images.pullPolicy" (dict "image" $rootImage "defaults" $.Values.defaults) }}
-        securityContext: # need to run as root with privileged mode
-          {{- include "solo.root.security.context.privileged" . | nindent 10 }}
         {{- with default $defaults.root.resources $node.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
@@ -573,8 +571,6 @@ spec:
       - name: {{ default "backup-uploader" $backupUploader.nameOverride }}
         image: {{ include "solo.container.image" (dict "image" $backupUploader.image "Chart" $.Chart "defaults" $defaults.sidecars.backupUploader) }}
         imagePullPolicy: {{ include "solo.images.pullPolicy" (dict "image" $backupUploader.image "defaults" $defaults.sidecars.backupUploader ) }}
-        securityContext: # backup.sh needs permission to create file at root directory
-          {{- include "solo.root.security.context.privileged" . | nindent 10 }}
         volumeMounts:
           - name: volume-for-share-version-file
             mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/VERSION

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -69,8 +69,8 @@ defaults:
   root: # root container
     image:
       registry: "ghcr.io"
-      repository: "hashgraph/solo-containers/ubi8-s6-java25"
-      tag: "0.43.0"
+      repository: "hashgraph/solo-containers/debian-s6-java25"
+      tag: "0.45.4"
       pullPolicy: "IfNotPresent"
     resources: { }
     extraEnv: [ ]
@@ -145,7 +145,7 @@ defaults:
       image:
         registry: "ghcr.io"
         repository: "hashgraph/solo-containers/backup-uploader"
-        tag: "0.41.2"
+        tag: "0.45.4"
         pullPolicy: "IfNotPresent"
       config:
         backupBucket: "backup"

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -70,7 +70,7 @@ defaults:
     image:
       registry: "ghcr.io"
       repository: "hashgraph/solo-containers/debian-s6-java25"
-      tag: "0.45.4"
+      tag: "0.46.0"
       pullPolicy: "IfNotPresent"
     resources: { }
     extraEnv: [ ]
@@ -145,7 +145,7 @@ defaults:
       image:
         registry: "ghcr.io"
         repository: "hashgraph/solo-containers/backup-uploader"
-        tag: "0.45.4"
+        tag: "0.46.0"
         pullPolicy: "IfNotPresent"
       config:
         backupBucket: "backup"


### PR DESCRIPTION
## Description

This pull request updates the container images used in the deployment and removes the use of a privileged root security context from the Kubernetes manifests. The main goals are to improve security by avoiding unnecessary privileged containers and to update to newer image versions.

**Image updates:**

* Updated the `root` container image from `hashgraph/solo-containers/ubi8-s6-java25:0.43.0` to `hashgraph/solo-containers/debian-s6-java25:0.45.4` in `values.yaml`.
* Updated the `backup-uploader` sidecar image tag from `0.41.2` to `0.45.4` in `values.yaml`.

**Security context changes:**

* Removed the `solo.root.security.context.privileged` template, which previously set containers to run as root with privileged mode, from `_helpers.tpl`.
* Removed the use of the privileged root security context from the `root` container spec in `network-node-statefulset.yaml`.
* Removed the use of the privileged root security context from the `backup-uploader` sidecar spec in `network-node-statefulset.yaml`.

### Related Issues

- Required by https://github.com/hiero-ledger/solo/issues/4002
