### PR TITLE
chore: Update NMT references

### DIFF
--- a/.github/workflows/support/scripts/helper.sh
+++ b/.github/workflows/support/scripts/helper.sh
@@ -14,7 +14,7 @@ HEDERA_HOME_DIR="/home/hedera"
 RELEASE_NAME="${RELEASE_NAME:-solo}"
 
 NMT_VERSION="${NMT_VERSION:-v1.3.4}"
-NMT_RELEASE_URL="https://api.github.com/repos/swirlds/swirlds-docker/releases/tags/${NMT_VERSION}"
+NMT_RELEASE_URL="https://api.github.com/repos/hashgraph/node-management-tools/releases/tags/${NMT_VERSION}"
 NMT_INSTALLER="node-mgmt-tools-installer-${NMT_VERSION}.run"
 NMT_INSTALLER_DIR="${SCRIPT_DIR}/../resources/nmt"
 NMT_INSTALLER_PATH="${NMT_INSTALLER_DIR}/${NMT_INSTALLER}"


### PR DESCRIPTION
## Description

This pull request updates the URL used to retrieve the Node Management Tools (NMT) release in the `helper.sh` script. The change ensures that the script now points to the correct GitHub repository for NMT releases.

- Updated the `NMT_RELEASE_URL` in `.github/workflows/support/scripts/helper.sh` to use the `hashgraph/node-management-tools` repository instead of the deprecated `swirlds/swirlds-docker` repository.

### Related Issues

- Closes #270
