### PR TITLE
fix: refuse to start a node whose claims are backed by undersized storage

### DIFF
--- a/charts/solo-deployment/templates/_helpers.tpl
+++ b/charts/solo-deployment/templates/_helpers.tpl
@@ -45,6 +45,37 @@ export MINIO_ROOT_USER={{ include "minio.accessKey" . }}
 export MINIO_ROOT_PASSWORD={{ include "minio.secretKey" . }}
 {{- end -}}
 
+{{/*
+Convert a Kubernetes storage quantity (500Gi, 100M, 2048) to whole kibibytes, so a shell script can
+compare it against `df -Pk` output without having to parse suffixes itself. Binary suffixes (Ki, Mi,
+Gi, Ti) and decimal SI suffixes (k, M, G, T) are different quantities and are converted separately;
+a bare number is bytes. Rounds down, which keeps the comparison conservative.
+*/}}
+{{- define "solo.quantityToKibibytes" -}}
+{{- $quantity := toString . -}}
+{{- $number := regexFind "^[0-9]+(\\.[0-9]+)?" $quantity | float64 -}}
+{{- $suffix := regexFind "[A-Za-z]+$" $quantity -}}
+{{- if eq $suffix "Ki" -}}
+{{- printf "%.0f" $number -}}
+{{- else if eq $suffix "Mi" -}}
+{{- printf "%.0f" (mulf $number 1024) -}}
+{{- else if eq $suffix "Gi" -}}
+{{- printf "%.0f" (mulf $number 1048576) -}}
+{{- else if eq $suffix "Ti" -}}
+{{- printf "%.0f" (mulf $number 1073741824) -}}
+{{- else if eq $suffix "k" -}}
+{{- printf "%.0f" (divf (mulf $number 1000) 1024) -}}
+{{- else if eq $suffix "M" -}}
+{{- printf "%.0f" (divf (mulf $number 1000000) 1024) -}}
+{{- else if eq $suffix "G" -}}
+{{- printf "%.0f" (divf (mulf $number 1000000000) 1024) -}}
+{{- else if eq $suffix "T" -}}
+{{- printf "%.0f" (divf (mulf $number 1000000000000) 1024) -}}
+{{- else -}}
+{{- printf "%.0f" (divf $number 1024) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "solo.volumeClaimTemplate" -}}
 - metadata:
     name: {{ .name }}

--- a/charts/solo-deployment/templates/network-node-statefulset.yaml
+++ b/charts/solo-deployment/templates/network-node-statefulset.yaml
@@ -15,6 +15,26 @@
 {{- $minioserver := (index $.Values "minio-server") }}
 {{- $nodeStorage := $.Values.defaults.volumeClaims.node }}
 {{- $pvcEnabled := $.Values.defaults.volumeClaims.enabled }}
+{{- $capacityCheck := $.Values.defaults.volumeClaims.capacityCheck }}
+{{/*
+Every claim-backed volume paired with the path root-container mounts it on and the size its claim
+requested. Kept in one place so the capacity check cannot drift from the claim templates above.
+*/}}
+{{- $claimMounts := list
+  (dict "name" "hgcapp-blockstream"  "path" "/opt/hgcapp/blockStreams"                                  "storage" $nodeStorage.blockStreams)
+  (dict "name" "hgcapp-event-streams" "path" "/opt/hgcapp/eventsStreams"                                "storage" $nodeStorage.eventStreams)
+  (dict "name" "hgcapp-record-streams" "path" "/opt/hgcapp/recordStreams"                               "storage" $nodeStorage.recordStreams)
+  (dict "name" "hgcapp-data-onboard"  "path" "/opt/hgcapp/services-hedera/HapiApp2.0/data/onboard"      "storage" $nodeStorage.dataOnboard)
+  (dict "name" "hgcapp-data-saved"    "path" "/opt/hgcapp/services-hedera/HapiApp2.0/data/saved"        "storage" $nodeStorage.dataSaved)
+  (dict "name" "hgcapp-data-stats"    "path" "/opt/hgcapp/services-hedera/HapiApp2.0/data/stats"        "storage" $nodeStorage.dataStats)
+  (dict "name" "hgcapp-data-upgrade"  "path" "/opt/hgcapp/services-hedera/HapiApp2.0/data/upgrade"      "storage" $nodeStorage.dataUpgrade)
+  (dict "name" "hgcapp-output"        "path" "/opt/hgcapp/services-hedera/HapiApp2.0/output"            "storage" $nodeStorage.output)
+  (dict "name" "hgcapp-data-config"   "path" "/opt/hgcapp/services-hedera/HapiApp2.0/data/config"       "storage" $nodeStorage.config)
+  (dict "name" "hgcapp-data-keys"     "path" "/opt/hgcapp/services-hedera/HapiApp2.0/data/keys"         "storage" $nodeStorage.keys)
+  (dict "name" "hgcapp-data-libs"     "path" "/opt/hgcapp/services-hedera/HapiApp2.0/data/lib"          "storage" $nodeStorage.dataLibs)
+  (dict "name" "hgcapp-data-apps"     "path" "/opt/hgcapp/services-hedera/HapiApp2.0/data/apps"         "storage" $nodeStorage.dataApps)
+  (dict "name" "hgcapp-state"         "path" "/opt/hgcapp/services-hedera/HapiApp2.0/state"             "storage" $nodeStorage.config)
+}}
 {{- $initContainersLength := len $.Values.hedera.initContainers }}
 {{- $cheetah := $.Values.cheetah }}
 {{- $bucketPrefixString := toString $cloud.buckets.streamBucketPrefix }}
@@ -668,6 +688,63 @@ spec:
       {{- end }}
 
       initContainers:
+        {{- if and $pvcEnabled $capacityCheck.enabled }}
+        # Fail before the consensus node starts if a claim was satisfied from a filesystem too small
+        # to hold it. The claim itself cannot reveal this: a provisioner that hands out directories
+        # on an existing filesystem binds the claim, reports the requested size back, and mounts it
+        # successfully whatever the size of the underlying disk. Comparing the mounted filesystem
+        # against the requested size is the only way to see it, and doing so here means the node
+        # never writes state to the wrong device.
+        - name: init-verify-volume-capacity
+          image: busybox:1.36.1
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              tolerance_percent={{ $capacityCheck.tolerancePercent }}
+              failures=0
+
+              check_capacity() {
+                mount_path="$1"
+                requested_kib="$2"
+                available_kib="$(df -Pk "$mount_path" 2>/dev/null | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2)"
+
+                # `df` prints only its header for a path it cannot stat, which would leave a
+                # non-numeric value here and make the comparison below fall through to a pass.
+                case "$available_kib" in
+                  '' | *[!0-9]*)
+                    echo "SKIP $mount_path: filesystem size unavailable"
+                    return
+                    ;;
+                esac
+
+                minimum_kib=$(( requested_kib * tolerance_percent / 100 ))
+                if [ "$available_kib" -lt "$minimum_kib" ]; then
+                  echo "FAIL $mount_path: backed by ${available_kib}KiB, claim requested ${requested_kib}KiB"
+                  failures=$(( failures + 1 ))
+                else
+                  echo "OK   $mount_path: backed by ${available_kib}KiB, claim requested ${requested_kib}KiB"
+                fi
+              }
+
+              {{- range $claimMount := $claimMounts }}
+              check_capacity {{ $claimMount.path | quote }} {{ include "solo.quantityToKibibytes" $claimMount.storage }}
+              {{- end }}
+
+              if [ "$failures" -ne 0 ]; then
+                echo ""
+                echo "$failures volume(s) are backed by less storage than their PersistentVolumeClaim requested."
+                echo "The provisioner satisfied these claims from a filesystem too small to hold them, which"
+                echo "usually means the storage class writes into a directory that is not on the intended"
+                echo "device. Check the provisioner's host path with: findmnt <path>; lsblk; df -h <path>"
+                exit 1
+              fi
+          volumeMounts:
+            {{- range $claimMount := $claimMounts }}
+            - name: {{ $claimMount.name }}
+              mountPath: {{ $claimMount.path }}
+            {{- end }}
+        {{- end }}
+
         {{- if $backupUploader.enabled }}
         # create empty VERSION file before any volume mounted
         # otherwise VERSION will be mounted as directory by backup-uploader

--- a/charts/solo-deployment/values.yaml
+++ b/charts/solo-deployment/values.yaml
@@ -52,6 +52,16 @@ defaults:
   volumeClaims:
     enabled: false
     storageClassName: ""
+    # Refuse to start a consensus node whose claims were satisfied from a filesystem too small to
+    # hold them. Provisioners that hand out directories on an existing filesystem (hostPath,
+    # local-path) ignore the requested size, so a claim binds and mounts against any disk and
+    # Kubernetes reports nothing wrong. Disabled by default because a development or single-disk
+    # cluster is legitimately oversubscribed by the sizes below.
+    capacityCheck:
+      enabled: false
+      # Percentage of the requested size a mount must provide. Filesystem metadata overhead means a
+      # correctly provisioned volume reports slightly less than requested.
+      tolerancePercent: 90
     node:
       eventStreams: "100Gi"
       recordStreams: "100Gi"


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds an opt-in `init-verify-volume-capacity` init container to the network node StatefulSet. It compares each claim-backed mount's actual filesystem size against the size its PersistentVolumeClaim requested and fails the pod when a mount provides materially less, so a consensus node never starts on storage that cannot hold what it asked for.
- Adds `defaults.volumeClaims.capacityCheck` with `enabled: false` and `tolerancePercent: 90`. The check is **off by default**: a development or single-disk cluster (kind included) is legitimately oversubscribed by the per-node claim sizes in `defaults.volumeClaims.node`, and enabling this by default would stop those clusters from booting. The tolerance exists because a correctly provisioned volume reports slightly less than requested once formatted.
- Adds a `solo.quantityToKibibytes` helper that converts a Kubernetes storage quantity to whole kibibytes at render time, so the init container's shell only compares integers against `df -Pk`. Binary and decimal SI suffixes are converted separately, since `1Gi` (1073741824) and `1G` (1000000000) are different quantities.
- Collects the claim-backed volumes, their `root-container` mount paths, and their requested sizes into a single `$claimMounts` list, so the capacity check cannot drift from the claim templates it is checking.

### Why this belongs in the chart

The requested sizes in `defaults.volumeClaims.node` are advisory only. Provisioners that hand out directories on an existing filesystem — hostPath, `rancher.io/local-path`, and most bare-metal setups — ignore `spec.resources.requests.storage` entirely: the claim binds, reports the requested size back through `status.capacity`, mounts successfully, and the node starts writing, whatever the size of the underlying disk. The claim, the pod status, and the events all look healthy.

This was hit on a bare-metal cluster where the provisioner's host directory (`/opt`) was not on the intended device — the mdadm array was not mounted there, so all 13 claims per node landed on the small system disk. A 500Gi `dataSaved` claim was backed by a few hundred GB shared with 12 other claims and the OS.

hiero-ledger/solo#5876 adds the equivalent verification on the solo side, but that check necessarily runs after the pods reach `Running`, so the node has already started by the time it reports. Placing the guard here fails **before** the consensus node writes any state to the wrong device, and covers anyone installing the chart directly rather than through solo.

### Related Issues

- Closes #283
- Related to hiero-ledger/solo#5875, hiero-ledger/solo#5876

### Pull request (PR) checklist

- [x] This PR added tests (unit, integration, and/or end-to-end)
- [ ] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [x] This PR has no breaking changes
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description

No behaviour changes for any existing deployment: with `capacityCheck.enabled` at its `false` default, the rendered manifest is byte-identical to before. The init container is also suppressed when `volumeClaims.enabled` is `false`, where the volumes are `emptyDir` and there is no claim to check against.

### Testing

The following manual testing was done:

- `helm lint` passes.
- Render gating verified across all four combinations: the init container is absent by default, absent with `volumeClaims.enabled=true` alone, absent with `capacityCheck.enabled=true` alone, and present only when both are set.
- Quantity conversion verified in the rendered output: `500Gi` → `524288000` KiB, `100Gi` → `104857600` KiB, `1Gi` → `1048576` KiB, and the fractional case `1.5Ti` → `1610612736` KiB.
- The generated script was executed in `busybox:1.36.1` against real `df` output and confirmed on all three branches: a 500Gi request against the (smaller) container root reports `FAIL` and exits 1, a 1Gi request against the same filesystem reports `OK` and exits 0, and an unstattable path reports `SKIP` without failing.
- That last case caught a bug during development worth calling out: busybox `df` prints only its header row for a path it cannot stat, so `tail -n 1 | cut -d ' ' -f 2` yielded the literal string `1024-blocks`. The numeric comparison then errored and fell through to the success branch, reporting `OK` for a mount that had not been verified at all. The script now rejects any non-numeric value with a `case` guard before comparing.

The following was not tested:

- No end-to-end run against a bare-metal cluster with a deliberately misconfigured storage mount point. The failure path was exercised by pointing the check at a filesystem smaller than the requested size, which is the same comparison.
